### PR TITLE
Quick fix.

### DIFF
--- a/src/api/admin/admin.test.js
+++ b/src/api/admin/admin.test.js
@@ -3,7 +3,7 @@ const request = require('supertest');
 const app = require('../../app');
 
 describe('GET /admin', () => {
-  it('Should respond with a 401 status code', done => {
+  it('Should respond with a 404 status code', done => {
     request(app)
       .get('/admin')
       .expect('Content-Type', /json/)


### PR DESCRIPTION
Changed
```it('Should respond with a 401 status code', done => {``` to
  ```it('Should respond with a 404 status code', done => {``` on `admin.test.js`